### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - Claude-Code
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically deploy the project to GitHub Pages whenever changes are pushed to the `Claude-Code` branch.

## Changes
- Added `.github/workflows/deploy.yml` workflow file that:
  - Triggers on push events to the `Claude-Code` branch and manual workflow dispatch
  - Checks out the repository code
  - Configures GitHub Pages settings
  - Uploads the entire repository as a deployment artifact
  - Deploys the artifact to GitHub Pages using the official deployment action

## Implementation Details
- Uses the latest versions of GitHub's official actions (checkout@v4, configure-pages@v5, upload-pages-artifact@v3, deploy-pages@v4)
- Includes appropriate permissions for pages write access and OIDC token generation
- Implements concurrency control to prevent simultaneous deployments
- Deploys the entire repository root (`'.'`) as the static site content

https://claude.ai/code/session_01C4sL82Me8tLhZ1w59Pdeem