### PR TITLE
Add default document: Große Kampagnen gegen das Osmanische Reich

### DIFF
--- a/app.js
+++ b/app.js
@@ -3232,6 +3232,10 @@ async function init() {
         } else {
             loadPDF(new Blob([cached], { type: "application/pdf" }), cachedName);
         }
+    } else if (typeof generateDefaultDocumentPDF === 'function') {
+        // No cached document — load the bundled default document
+        const defaultBlob = generateDefaultDocumentPDF();
+        loadPDF(defaultBlob, DEFAULT_DOCUMENT_TITLE + '.pdf');
     }
 }
 init();

--- a/default-document.js
+++ b/default-document.js
@@ -1,0 +1,236 @@
+// Default document: "Große Kampagnen gegen das Osmanische Reich"
+// This text is bundled as the default PDF that loads on first visit (no cached document).
+// To change the default document, edit the sections array below.
+
+const DEFAULT_DOCUMENT_TITLE = "Große Kampagnen gegen das Osmanische Reich";
+
+const DEFAULT_DOCUMENT_SECTIONS = [
+{
+    heading: "Einleitung",
+    body: `Das Osmanische Reich (1299–1922) war über Jahrhunderte eine der mächtigsten Supermächte der Welt. Von seinen Ursprüngen in Anatolien expandierte es auf drei Kontinente und bedrohte wiederholt das Herz Europas. Die militärischen Kampagnen gegen die Osmanen umfassen eine beeindruckende Zeitspanne von fast 600 Jahren – von den frühen Kreuzzügen bis zum Ende des Ersten Weltkriegs.
+
+Diese Kämpfe prägten die politische und kulturelle Entwicklung Europas fundamental. Sie waren nicht nur militärische Auseinandersetzungen, sondern auch Aufeinandertreffen zweier Welten, zweier Kulturen und zweier religiöser Systeme. Die folgenden Kapitel beleuchten die bedeutendsten Kampagnen, Schlachten und Wendepunkte in diesem jahrhundertelangen Konflikt.`
+},
+{
+    heading: "Die späten Kreuzzüge gegen die Osmanen",
+    subheading: "Der Kreuzzug von Nikopolis (1396)",
+    body: `Der Kreuzzug von Nikopolis gilt als einer der letzten großen Kreuzzüge des Mittelalters. Papst Bonifaz IX. hatte zum heiligen Krieg gegen die osmanische Expansion auf dem Balkan aufgerufen. Ein gewaltiges Kreuzfahrerheer sammelte sich, angeführt von König Sigismund von Ungarn und dem französischen Edelmann Johann Ohnefurcht, Herzog von Burgund.
+
+Am 25. September 1396 kam es bei Nikopolis in Bulgarien zur entscheidenden Schlacht. Das Kreuzritterheer, bestehend aus schwer gepanzerten Rittern, griff zunächst erfolgreich an. Die Reiter von Sultan Bayezit I. gerieten ins Hintertreffen, doch eine plötzliche Kavallerieattacke seiner serbischen Vasallen wendete das Blatt.
+
+Das Ergebnis war vernichtend: Das Kreuzritterheer wurde vollständig aufgerieben. Etwa 3.000 Gefangene, die kein Lösegeld zahlen konnten, wurden auf Befehl des Sultans umgebracht. Die Niederlage von Nikopolis markierte das faktische Ende der Kreuzzugsbewegung gegen die Osmanen.`
+},
+{
+    subheading: "Der letzte Kreuzzug: Schlacht bei Varna (1444)",
+    body: `Knapp 50 Jahre später unternahm Europa einen letzten verzweifelten Versuch, die osmanische Expansion zu stoppen. Papst Eugen IV. hatte 1440 einen neuen Kreuzzug gepredigt, der sich gegen die Osmanen unter Sultan Murad II. richtete. Der Anlass war die bedrohliche Lage des Byzantinischen Reiches und die türkische Vorherrschaft auf dem Balkan.
+
+Unter der Führung des siebenbürgischen Herzogs Johann Hunyadi waren alliierte Truppen zunächst erfolgreich. Sie schlugen die Osmanen mehrfach und drängten sie in die Defensive. Sogar Soldaten des byzantinischen Außenpostens Mistra auf der Peloponnes beteiligten sich an der Offensive.
+
+Der junge polnisch-ungarische König Wladislaw III. führte das Kreuzfahrerheer persönlich an. Doch am 10. November 1444 kam es bei Varna in Bulgarien zur Katastrophe. Sultan Murad II. siegte entscheidend. König Wladislaw fiel in der Schlacht, sein Kopf schmückte anschließend die Spitze eines osmanischen Speeres.
+
+Dieser "letzte Kreuzzug" endete mit einem Desaster. Fast nur noch Ritter aus dem Balkanraum waren dem päpstlichen Aufruf gefolgt – die westeuropäischen Mächte hatten kein Interesse mehr an kostspieligen Kreuzzügen.`
+},
+{
+    heading: "Die Türkenkriege: Ungarn und Österreich",
+    subheading: "Schlacht bei Mohács (1526)",
+    body: `Die Schlacht bei Mohács am 29. August 1526 war eine der folgenschwersten Niederlagen in der ungarischen Geschichte. Sultan Süleyman I. "der Prächtige" hatte von Ungarn Tributzahlungen gefordert. Als Ungarn die Zahlung verweigerte, marschierte er mit einer etwa 60.000 bis 70.000 Mann starken Armee Richtung Norden.
+
+Zur osmanischen Streitmacht gehörten 10.000 Sipahis (Reiter) und 12.000 Janitscharen als Elitetruppen – die gefürchtetsten Soldaten ihrer Zeit. Das ungarische Heer unter König Ludwig II. und Pál Tomori war deutlich schwächer und schlecht organisiert.
+
+Die Schlacht selbst war kurz und brutal. Die ungarischen Ritter griffen mutig an, doch die Sipahis zogen sich geordnet zurück und lockten die Ungarn in einen Hinterhalt osmanischer Artillerie. Im verheerenden Geschützfeuer wurden zahlreiche Ungarn getötet, Panik brach aus.
+
+Die fliehenden ungarischen Einheiten wurden in die Sümpfe getrieben. Am Ende fielen 24.000 Mann, darunter 4.000 Panzerreiter. 12.000 weitere wurden enthauptet. König Ludwig II. ertrank auf der Flucht im Bach Csele – seine Leiche wurde erst zwei Monate später gefunden.
+
+Die Folgen waren verheerend: Die Osmanen eroberten am 10. September die ungarische Hauptstadt Buda und plünderten die königliche Residenz. Mehr als 100.000 Ungarn wurden in die Sklaverei geführt. Das Königreich Ungarn hörte als unabhängiger Staat faktisch auf zu existieren.`
+},
+{
+    subheading: "Die erste Wiener Türkenbelagerung (1529)",
+    body: `Nach dem vernichtenden Sieg bei Mohács setzte Sultan Süleyman I. seine Expansion fort. Wien, die habsburgische Kaiserstadt, war das nächste Ziel. Am 10. Mai 1529 brach ein gewaltiges osmanisches Heer von 150.000 Mann (davon 60.000 Mann Tross) aus Istanbul auf.
+
+Der Vormarsch war systematisch: Am 17. Juli fiel Belgrad, am 8. September die ungarische Hauptstadt Ofen. Am 22. September überschritt die osmanische Vorhut die österreichische Grenze. Bereits am 23. September erreichten die ersten Einheiten beim Niklaskloster die Wiener Vorstadt Landstraße.
+
+Am 25. September 1529 begann die eigentliche Belagerung. Die Situation schien hoffnungslos. Wien war eine relativ kleine, veraltete Festung mit nur etwa 16.000 Verteidigern, darunter 1.000 spanische und deutsche Söldner. Die Verteidigung lag in den Händen von Niklas Graf Salm und Philipp Graf Salm.
+
+Die Osmanen konzentrierten ihren Angriff auf den Kärntner Turm, der von Eck von Reischach tapfer verteidigt wurde. Doch die eigentliche Gefahr kam von unten: Ein brutaler Minenkrieg begann. Die Türken trieben unterirdische Stollen vor und versuchten, die Stadtmauern durch Sprengungen zum Einsturz zu bringen.
+
+Drei Wochen lang tobte die Belagerung. Doch mehrere Faktoren arbeiteten gegen die Belagerer: Das Wetter verschlechterte sich dramatisch, Herbstregen verwandelte das Lager in einen Morast. Die Versorgungsprobleme wurden kritisch – die schwere Belagerungsartillerie war im Schlamm steckengeblieben. Zudem erlitten die Osmanen hohe Verluste bei ihren Sturmangriffen.
+
+Am 15. Oktober 1529 brach Sultan Süleyman die Belagerung ab und zog sich zurück. Wien hatte überlebt. Mit diesem Rückzug endete der "Mythos der osmanischen Unbesiegbarkeit" – zum ersten Mal hatte eine europäische Stadt einer osmanischen Großoffensive standgehalten.`
+},
+{
+    subheading: "Schlacht bei Mogersdorf (1664)",
+    body: `Der nächste große osmanische Vorstoß kam 1663. Großwesir Ahmed Köprülü setzte am 12. April 1663 in Edirne ein etwa 100.000 Mann starkes Heer in Marsch. Die diplomatischen Versuche zur Friedensverlängerung zwischen dem Osmanischen Reich und Habsburg waren gescheitert.
+
+Im August 1664 kam es zur entscheidenden Schlacht bei Mogersdorf im Burgenland. Der kaiserliche Feldherr Raimondo Montecuccoli kommandierte die habsburgischen Truppen. Nach einem nächtlichen Artilleriefeuer griffen am Morgen des 1. August rund 12.000 Türken die kaiserlichen Stellungen an.
+
+Die Schlacht dauerte zehn blutige Stunden. Montecuccoli nutzte geschickt das Gelände und seine überlegene Artillerie. Aus der Schlacht ging er als Sieger hervor. Die Osmanen verloren etwa 10.000 Mann, während auf kaiserlicher Seite "lediglich" 2.000 Tote zu beklagen waren.
+
+Obwohl der Sieg bei Mogersdorf militärisch bedeutsam war, wurde im anschließenden Frieden von Eisenburg (Vasvár) nur ein 20-jähriger Waffenstillstand vereinbart. Viele Zeitgenossen kritisierten, dass Kaiser Leopold I. nicht mehr aus dem Sieg herausgeholt hatte.`
+},
+{
+    subheading: "Die zweite Wiener Türkenbelagerung (1683)",
+    body: `Die zweite Belagerung Wiens im Jahr 1683 war eine der größten Schlachten des 17. Jahrhunderts und markierte den Wendepunkt in den Türkenkriegen. Im Frühjahr 1683 brach Großwesir Kara Mustafa mit einer gewaltigen Armee von etwa 150.000 bis 200.000 Mann von Istanbul auf.
+
+Am 14. Juli 1683 erreichten die osmanischen Truppen Wien und schlossen die Stadt ein. Nur etwa 11.000 Verteidiger und 5.000 Wiener Bürger standen dem osmanischen Heer gegenüber. Die Kommandanten Rüdiger von Starhemberg und Ernst Rüdiger Graf von Starhemberg organisierten eine verzweifelte Verteidigung.
+
+Zwei Monate lang hielten die Wiener durch, während Kara Mustafa systematisch versuchte, die Festung durch Beschuss, Minen und Sturmangriffe zu brechen. Die Lage wurde zunehmend kritisch – Hunger, Seuchen und Munitionsmangel plagten die Verteidiger.
+
+Doch Kaiser Leopold I. hatte nicht untätig zugesehen. Er schmiedete eine mächtige Allianz mit Polen, deutschen Fürsten und dem Papst – die sogenannte "Heilige Liga". Am 12. September 1683 traf das Entsatzheer unter Führung des polnischen Königs Johann III. Sobieski auf dem Kahlenberg ein.
+
+Die Schlacht am Kahlenberg begann früh am Morgen des 12. September. Trotz der zahlenmäßigen Überlegenheit der Osmanen gelang es Sobieski durch brillante Taktik, das Blatt zu wenden. Den Höhepunkt bildete eine massive Kavallerie-Attacke der polnischen Husaren, die vom Kahlenberg herab auf die osmanischen Linien donnerten.
+
+Diese Attacke – die größte Kavallerie-Attacke der Geschichte mit etwa 20.000 Reitern – zerschmetterte die osmanische Armee. Kara Mustafa musste fliehen und ließ das gesamte Lager mit unermesslichen Schätzen zurück. Der Sieg bei Wien am 12. September 1683 beendete die osmanische Expansion nach Europa endgültig.`
+},
+{
+    subheading: "Der Große Türkenkrieg (1683–1699)",
+    body: `Nach dem Sieg bei Wien ging Kaiser Leopold I. in die Offensive. Der "Große Türkenkrieg" begann – eine systematische Rückeroberung der von den Osmanen besetzten Gebiete. Zwei geniale Feldherren führten die habsburgischen Truppen: Ludwig Wilhelm von Baden, genannt "der Türkenlouis", und vor allem Prinz Eugen von Savoyen.
+
+Am 2. September 1686 eroberten die Truppen der Heiligen Liga nach schweren Kämpfen die ungarische Festung Ofen (Buda) zurück – nach 145 Jahren osmanischer Herrschaft. Es war ein symbolischer Triumph von immenser Bedeutung.
+
+In den folgenden Jahren errangen Prinz Eugen und der Türkenlouis eine Reihe spektakulärer Siege. Besonders bedeutsam waren die Schlacht bei Zenta am 11. September 1697 und die Schlacht von Peterwardein 1716. Prinz Eugen vernichtete bei Zenta eine 80.000 Mann starke osmanische Armee und tötete etwa 30.000 Türken bei nur 400 eigenen Verlusten.
+
+Der Große Türkenkrieg endete 1699 mit dem Frieden von Karlowitz. Das Osmanische Reich musste nahezu ganz Ungarn, Siebenbürgen und große Teile Kroatiens an die Habsburger abtreten. Es war die erste große territoriale Niederlage in der osmanischen Geschichte – ein historischer Wendepunkt.`
+},
+{
+    heading: "Seeschlachten im Mittelmeer",
+    subheading: "Die Schlacht von Lepanto (1571)",
+    body: `Die Seeschlacht von Lepanto am 7. Oktober 1571 war eine der bedeutendsten Marineschlachten der Weltgeschichte. Sie stoppte die osmanische Expansion im Mittelmeer und zählt zu den großen Wendemarken der Geschichte.
+
+Die osmanische Marine galt zu dieser Zeit als unbesiegbar. Ihre Marinesoldaten – darunter die gefürchteten Bogenschützen – waren die besten ihrer Zeit. Das Mittelmeer war dabei, ein "osmanisches Meer" zu werden, und christliche Handelswege waren akut bedroht.
+
+Als Reaktion formierte sich die "Heilige Liga" – eine Allianz aus Venedig, Spanien, Genua und dem Papst. Die vereinigte Flotte traf am Morgen des 7. Oktober 1571 vor Lepanto (heute: Nafpaktos in Griechenland) auf die osmanische Flotte.
+
+Die Schlacht war brutal und blutig. Doch die christliche Flotte verfügte über einen entscheidenden Vorteil: überlegene Technologie. Ihre Galeeren waren schwerer bewaffnet, ihre Geschütze feuerkräftiger. Vor allem sechs venezianische Galeassen – mit massiver Artillerie ausgerüstete Großschiffe – erwiesen sich als vernichtend.
+
+Nur wenige Stunden dauerte die Schlacht, dann hatten die osmanischen Marinesoldaten eine vernichtende Niederlage erlitten. Etwa 30.000 türkische Seeleute und Soldaten starben, darunter fast die gesamte Elite der osmanischen Bogenschützen. 15.000 christliche Galeerensklaven wurden befreit.
+
+Die Schlacht von Lepanto hatte tiefgreifende Folgen. Das Mittelmeer wurde wieder das "Meer der christlichen Römer". Die osmanische Marine erholte sich nie mehr vollständig von diesem Schlag. Lepanto markierte das Ende der osmanischen Seeherrschaft.`
+},
+{
+    subheading: "Gallipoli und der Erste Weltkrieg (1915–1916)",
+    body: `Über 340 Jahre später wurde die Meerenge der Dardanellen erneut zum Schauplatz eines gewaltigen Kampfes. Diesmal waren es die Alliierten – Großbritannien, Frankreich und das Commonwealth – die versuchten, das Osmanische Reich zu bezwingen.
+
+Winston Churchill, damals Erster Lord der Admiralität, war der Hauptarchitekt der Gallipoli-Kampagne. Sein Ziel war es, durch die Dardanellen durchzubrechen, das Osmanische Reich durch Bedrohung Konstantinopels aus dem Krieg zu drängen und eine Nachschubroute nach Russland über das Schwarze Meer zu öffnen.
+
+Die Kampagne begann im Februar 1915 mit einem Versuch, die Meeresenge durch einen Flottenvorstoß zu erzwingen. Doch die osmanischen Verteidigungsanlagen unter deutscher Führung waren stark: Hunderte von Minen, zahlreiche Küstenbatterien und gut ausgebaute Befestigungen machten den Durchbruch unmöglich.
+
+Am 25. April 1915 begannen die Alliierten mit amphibischen Landungen auf der Halbinsel Gallipoli. Australische und neuseeländische Truppen (ANZAC) landeten an der nach ihnen benannten ANZAC Cove, britische Truppen am Kap Helles. Die türkischen Verteidiger unter Mustafa Kemal (dem späteren Atatürk) leisteten erbitterten Widerstand.
+
+Acht Monate lang tobten blutige Grabenkämpfe auf engstem Raum. Die Kampfbedingungen waren infernalisch: Hitze, Dysenterie, Wassermangel und ständiger feindlicher Beschuss zermürbten die Truppen auf beiden Seiten. Trotz massiver Anstrengungen gelang den Alliierten kein entscheidender Durchbruch.
+
+Im Januar 1916 evakuierten die Alliierten schließlich ihre Truppen – die einzige perfekt durchgeführte Operation der gesamten Kampagne. Die Gallipoli-Kampagne war ein katastrophales Scheitern für die Alliierten: Über 250.000 Soldaten waren gefallen oder verwundet worden. Auf türkischer Seite waren die Verluste ähnlich hoch.
+
+Für das Osmanische Reich war Gallipoli jedoch ein symbolischer Triumph – der letzte große militärische Erfolg vor dem endgültigen Zusammenbruch 1918. Mustafa Kemal wurde zum Nationalhelden, der später die moderne Türkei begründen sollte.`
+},
+{
+    heading: "Die Arabische Revolte (1916–1918)",
+    body: `Während die Türken bei Gallipoli siegten, begann in ihrem eigenen Hinterland ein Aufstand, der das Reich in seinen Grundfesten erschüttern sollte. Die Arabische Revolte war ein von einigen arabischen Stämmen getragener Aufstand im Osmanischen Reich, der im Hedschas seinen Ausgang nahm.
+
+Großbritannien, vertreten durch T.E. Lawrence (später als "Lawrence von Arabien" berühmt), unterstützte die Revolte mit Geld, Waffen und militärischen Beratern. Ziel war es, die osmanischen Truppen zu binden und die Flanke der britischen Offensive in Palästina zu sichern.
+
+Am 10. Juni 1916 begann die Revolte mit Angriffen auf die osmanische Garnison in Mekka. Die Stadt Dschidda fiel am 16. Juni nach Beschuss durch britische Kriegsschiffe und Luftangriffe. Die Hafenstadt spielte fortan eine große Rolle für die Revolte, da dort Nachschub für die Beduinen eingeschifft werden konnte.
+
+In den folgenden zwei Jahren führten arabische Irreguläre unter Führung von Faisal, Sohn des Scherifen Hussein von Mekka, einen erfolgreichen Guerillakrieg. Hauptziel waren Sabotageaktionen gegen die Hedschasbahn – die lebenswichtige Eisenbahnlinie, die osmanische Truppen versorgte.
+
+Ein Höhepunkt war die Eroberung der Hafenstadt Akaba am 6. Juli 1917. Lawrence und Faisal führten ihre Beduinentruppen durch die "unpassierbare" Wüste Nefud und überraschten die osmanische Garnison von der Landseite – dort, wo niemand mit einem Angriff gerechnet hatte.
+
+Mit Akaba als Basis intensivierten die Aufständischen ihre Aktionen. Als am 8. Oktober 1917 britische Expeditionsstreitkräfte unter General Allenby bei Gaza durchbrachen und durch Palästina nach Norden vorrückten, brach die osmanische Front im Süden zusammen.
+
+Die Arabische Revolte trug erheblich zum Zusammenbruch des Osmanischen Reiches bei. Sie band zehntausende türkische Soldaten, zerstörte kritische Infrastruktur und untergrub die osmanische Herrschaft im arabischen Raum irreparabel.`
+},
+{
+    heading: "Der Zusammenbruch (1918–1920)",
+    body: `Der Erste Weltkrieg brachte in vielerlei Hinsicht Zerstörung über das Osmanische Reich und endete 1918 mit dessen totaler Niederlage. Am 30. Oktober 1918 musste das Osmanische Reich den Waffenstillstand von Mudros unterzeichnen – faktisch eine bedingungslose Kapitulation.
+
+Der Vertrag von Sèvres vom 10. August 1920 besiegelte das Schicksal des Reiches. Die Alliierten zerlegten das jahrhundertealte Imperium systematisch: Griechenland erhielt weite Teile Westanatoliens, einschließlich der Küstenregion um Smyrna (Izmir). Italien bekam Südwestanatolien zugesprochen. Frankreich erhielt ein Mandat über Syrien und den Libanon. Großbritannien übernahm Palästina, Mesopotamien (Irak) und faktisch die Kontrolle über die Meerengen. Ein unabhängiger armenischer Staat sollte in Ostanatolien entstehen. Ein kurdischer Staat wurde in Aussicht gestellt. Die Türkei selbst wurde auf einen kleinen Rumpfstaat in Zentralanatolien reduziert.
+
+Doch der Vertrag von Sèvres wurde nie vollständig umgesetzt. In Ankara organisierte Mustafa Kemal mit den Resten der osmanischen Truppen den Widerstand. Nur neun Tage nach der Unterzeichnung erklärte die Große Nationalversammlung alle Unterzeichner zu Hochverrätern.
+
+Es folgte der türkische Befreiungskrieg (1919–1923). Franzosen und Briten waren kriegsmüde, und die griechische Armee wurde in Anatolien zurückgeschlagen. Am 11. Oktober 1922 endete der griechisch-türkische Krieg mit einem türkischen Sieg.
+
+Der Vertrag von Lausanne vom 24. Juli 1923 ersetzte Sèvres und schuf die modernen Grenzen der Türkei – wesentlich größer als in Sèvres vorgesehen. Am 29. Oktober 1923 wurde die Republik Türkei ausgerufen. Das Osmanische Reich existierte nicht mehr.`
+},
+{
+    heading: "Fazit: Das Vermächtnis der Kämpfe",
+    body: `Die jahrhundertelangen Kampagnen gegen das Osmanische Reich prägten Europa und den Nahen Osten fundamental. Sie waren nicht nur militärische Auseinandersetzungen, sondern auch kulturelle und religiöse Konfrontationen, die bis heute nachwirken.
+
+Die großen Wendepunkte waren klar erkennbar: Die erste Wiener Belagerung 1529 stoppte die osmanische Expansion erstmals. Lepanto 1571 beendete die osmanische Seeherrschaft. Die zweite Wiener Belagerung 1683 und der anschließende Große Türkenkrieg leiteten den territorialen Rückgang ein. Der Erste Weltkrieg brachte schließlich das endgültige Ende des Reiches.
+
+Was bleibt, sind Erinnerungen an epische Schlachten, heldenhafte Verteidiger und tragische Niederlagen auf beiden Seiten. Die Osmanen waren würdige Gegner – militärisch innovativ, taktisch brillant und strategisch weitsichtig. Ihr Reich überdauerte über 600 Jahre, länger als die meisten anderen Imperien der Geschichte.
+
+Die Kämpfe gegen das Osmanische Reich waren somit nicht nur militärhistorisch bedeutsam, sondern prägten die Identität ganzer Nationen. Von den polnischen Husaren über Prinz Eugen bis zu Lawrence von Arabien – diese Konflikte schufen Mythen und Legenden, die bis heute weiterleben.`
+}
+];
+
+// Generate a PDF blob from the default document sections using jsPDF
+function generateDefaultDocumentPDF() {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF({ format: 'a4', unit: 'mm' });
+
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    const margin = 20;
+    const textWidth = pageWidth - margin * 2;
+    let y = margin;
+
+    function checkPageBreak(needed) {
+        if (y + needed > pageHeight - margin) {
+            doc.addPage();
+            y = margin;
+        }
+    }
+
+    // Title page
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(24);
+    const titleLines = doc.splitTextToSize(DEFAULT_DOCUMENT_TITLE, textWidth);
+    y = 80;
+    doc.text(titleLines, pageWidth / 2, y, { align: 'center' });
+    y += titleLines.length * 12 + 20;
+
+    doc.setFontSize(12);
+    doc.setFont('helvetica', 'italic');
+    doc.text('Ein historischer Überblick', pageWidth / 2, y, { align: 'center' });
+
+    // Content pages
+    doc.addPage();
+    y = margin;
+
+    DEFAULT_DOCUMENT_SECTIONS.forEach(section => {
+        if (section.heading) {
+            checkPageBreak(20);
+            doc.setFont('helvetica', 'bold');
+            doc.setFontSize(16);
+            const headLines = doc.splitTextToSize(section.heading, textWidth);
+            doc.text(headLines, margin, y);
+            y += headLines.length * 8 + 6;
+        }
+
+        if (section.subheading) {
+            checkPageBreak(14);
+            doc.setFont('helvetica', 'bold');
+            doc.setFontSize(13);
+            const subLines = doc.splitTextToSize(section.subheading, textWidth);
+            doc.text(subLines, margin, y);
+            y += subLines.length * 7 + 4;
+        }
+
+        if (section.body) {
+            doc.setFont('helvetica', 'normal');
+            doc.setFontSize(11);
+            const paragraphs = section.body.split('\n\n');
+            paragraphs.forEach(para => {
+                const lines = doc.splitTextToSize(para.trim(), textWidth);
+                lines.forEach(line => {
+                    checkPageBreak(6);
+                    doc.text(line, margin, y);
+                    y += 5.5;
+                });
+                y += 3; // paragraph spacing
+            });
+            y += 4; // section spacing
+        }
+    });
+
+    return doc.output('blob');
+}

--- a/index.html
+++ b/index.html
@@ -1253,6 +1253,7 @@
   <!-- Hidden Inputs -->
   <input type="file" id="pdf-input" accept=".pdf,.epub,image/*" class="hidden">
   <input type="file" id="ocr-input" accept="image/*" class="hidden">
+  <script src="default-document.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Bundles a German-language history text about campaigns against the Ottoman Empire as the default PDF that auto-loads on first visit (when no cached document exists).

- default-document.js: Full text in 13 sections, generates PDF via jsPDF
- index.html: loads default-document.js before app.js
- app.js: init() falls back to generateDefaultDocumentPDF() when no cache

The text covers Nikopolis (1396) through the Treaty of Lausanne (1923), with battles at Varna, Mohács, Vienna (1529/1683), Lepanto, Gallipoli, and the Arab Revolt — ideal for demonstrating the map overlay features.

https://claude.ai/code/session_01C4sL82Me8tLhZ1w59Pdeem